### PR TITLE
Add healthcheck api endpoint

### DIFF
--- a/web-app/api.py
+++ b/web-app/api.py
@@ -18,8 +18,10 @@ app = FastAPI(title="Kelsa Work API", description="API for work tracking data")
 kafka_producer = KafkaProducer(bootstrap_servers=['localhost:9094'])
 work_ingestion_service = KafkaWorkIngestionService(logger, kafka_producer, 'work-topic')
 
-# TODO
-# - Add a health check endpoint
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy"}
 
 @app.middleware("http")
 async def auth(request: Request, call_next):


### PR DESCRIPTION
Add a simple healthcheck API to return 2xx status for service monitoring.

---

[Open in Web](https://cursor.com/agents?id=bc-d3a5c229-7d86-4abf-87ec-212668f616af) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d3a5c229-7d86-4abf-87ec-212668f616af) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)